### PR TITLE
update to v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-lwe"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Implements the module learning-with-errors public key encrpytion scheme."
 license = "MIT"


### PR DESCRIPTION
this improves the documentation and provides some doctests, along with removing a utility module that re-implemented some ring-lwe functions called `ring_mod.rs`. we now import directly from `ring-lwe`. 

we also remove functions from `lib.rs` that are used in other modules, and move them to a separate module `utils.rs`.