### PR TITLE
update to v.0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-lwe"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Implements the module learning-with-errors public key encrpytion scheme."
 license = "MIT"


### PR DESCRIPTION
uses `ring_lwe::utils::polymul_fast` rather than `ring_lwe::utils::polymul` for polynomial multiplcation. 