### PR TITLE
add benchmark times to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ Decrypts the ciphertext given a secret key, printing the plaintext message.
 
 **Benchmarks**
 
-| n  | q     | k  | keygen   | encrypt   | decrypt   | keygen_string | encrypt_string | decrypt_string |
-|----|-------|----|----------|-----------|-----------|---------------|----------------|----------------|
-| 32 | 12289 | 8  | 286.05 µs| 230.64 µs | 24.253 µs | 397.93 µs     | 545.25 µs      | 64.615 µs      |
+| n  | q     | k | keygen   | encrypt   | decrypt   | keygen_string | encrypt_string | decrypt_string |
+|----|-------|---|----------|-----------|-----------|---------------|----------------|----------------|
+| 32 | 12289 | 8 | 286.05 µs| 230.64 µs | 24.253 µs | 397.93 µs     | 545.25 µs      | 64.615 µs      |

--- a/README.md
+++ b/README.md
@@ -41,3 +41,8 @@ Generates the ciphertext.
 
 Decrypts the ciphertext given a secret key, printing the plaintext message.
 
+**Benchmarks**
+
+| n  | q     | k  | keygen   | encrypt   | decrypt   | keygen_string | encrypt_string | decrypt_string |
+|----|-------|----|----------|-----------|-----------|---------------|----------------|----------------|
+| 32 | 12289 | 8  | 286.05 µs| 230.64 µs | 24.253 µs | 397.93 µs     | 545.25 µs      | 64.615 µs      |


### PR DESCRIPTION
add benchmark times for `keygen`, `encrypt`, `decrypt`, `keygen_string`, `encrypt_string`, `decrypt_string`.