### PR TITLE
use base64 encoding for sk, pk, ct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ rand = "0.8.5"
 rand_distr = "0.4.3"
 ntt = "0.1.9"
 ring-lwe = "0.1.6"
+base64 = "0.21"
+bincode = "1.3"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -43,11 +43,11 @@ pub fn decrypt(
 
 /// decrypt a ciphertext string given a secret key
 /// # Arguments
-/// * `sk_string` - secret key string
-/// * `ciphertext_string` - ciphertext string
+/// * `sk_string` - secret key string in base64 encoding
+/// * `ciphertext_string` - ciphertext string in base64 encoding
 /// * `params` - Parameters for the ring-LWE cryptosystem
 /// # Returns
-/// * `message_string` - decrypted message string
+/// * `message_string` - decrypted message string as plaintext
 pub fn decrypt_string(sk_string: &String, ciphertext_base64: &String, params: &Parameters) -> String {
     // Get parameters
     let (n, k) = (params.n, params.k);

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -1,6 +1,8 @@
 use polynomial_ring::Polynomial;
 use ring_lwe::utils::{polysub,nearest_int};
 use crate::utils::{Parameters,mul_vec_simple};
+use base64::{engine::general_purpose, Engine as _};
+use bincode;
 
 /// Decrypt a ciphertext
 /// # Arguments
@@ -46,55 +48,59 @@ pub fn decrypt(
 /// * `params` - Parameters for the ring-LWE cryptosystem
 /// # Returns
 /// * `message_string` - decrypted message string
-pub fn decrypt_string(sk_string: &String, ciphertext_string: &String, params: &Parameters) -> String {
-
-    //get parameters
+pub fn decrypt_string(sk_string: &String, ciphertext_base64: &String, params: &Parameters) -> String {
+    // Get parameters
     let (n, k) = (params.n, params.k);
-    
-    // Convert the secret key string into a Vec<Polynomial<i64>>
-    let sk_array: Vec<i64> = sk_string.split(',')
-        .filter_map(|s| s.parse().ok())
-        .collect();
+
+    // Base64 decode the secret key string
+    let sk_bytes = general_purpose::STANDARD.decode(sk_string).expect("Failed to decode base64 secret key");
+
+    // Deserialize the secret key from bytes (it was serialized with bincode)
+    let sk_array: Vec<i64> = bincode::deserialize(&sk_bytes).expect("Failed to deserialize secret key");
+
+    // Convert the secret key into a Vec<Polynomial<i64>>
     let sk: Vec<Polynomial<i64>> = sk_array.chunks(n)
         .map(|chunk| Polynomial::new(chunk.to_vec()))
         .collect();
-    
-    // Parse ciphertext into u and v
-    let ciphertext_list: Vec<i64> = ciphertext_string.split(',')
-        .filter_map(|s| s.parse().ok())
-        .collect();
+
+    // Base64 decode the ciphertext string
+    let ciphertext_bytes = general_purpose::STANDARD.decode(ciphertext_base64).expect("Failed to decode ciphertext");
+
+    // Deserialize the ciphertext list from the decoded bytes
+    let ciphertext_list: Vec<i64> = bincode::deserialize(&ciphertext_bytes).expect("Failed to deserialize ciphertext");
+
     let block_size = (k + 1) * n;
     let num_blocks = ciphertext_list.len() / block_size;
 
     let mut message_binary = vec![];
-    
+
     for i in 0..num_blocks {
         // Get u and v for this block
         let u_array = &ciphertext_list[i * block_size..i * block_size + k * n];
         let v_array = &ciphertext_list[i * block_size + k * n..(i + 1) * block_size];
-            
+        
         let u: Vec<Polynomial<i64>> = u_array.chunks(n)
             .map(|chunk| Polynomial::new(chunk.to_vec()))
             .collect();
         let v = Polynomial::new(v_array.to_vec());
-            
+        
         // Decrypt the ciphertext
         let mut m_b = decrypt(&sk, &u, &v, &params);
-        m_b.resize(n,0);
-            
+        m_b.resize(n, 0);
+        
         message_binary.extend(m_b);
     }
-    
+
     // Group the bits back into bytes (8 bits each)
     let byte_chunks: Vec<String> = message_binary.chunks(8)
         .map(|chunk| chunk.iter().map(|bit| bit.to_string()).collect())
         .collect();
-        
+
     // Convert each binary string back into a character
     let message_string: String = byte_chunks.iter()
         .map(|byte| char::from_u32(i64::from_str_radix(byte, 2).unwrap() as u32).unwrap())
         .collect();
-    
-    //trim the null characters \0 = '00000000' from the end
+
+    // Trim the null characters \0 = '00000000' from the end
     message_string.trim_end_matches('\0').to_string()
 }

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -45,8 +45,6 @@ pub fn encrypt(
     // Compute u = a^T * r + e_1 mod q
     let u = add_vec(&mul_mat_vec_simple(&transpose(a), &r, q, f, omega), &e1, q, f);
 
-    println!("t: {:?}", t);
-
     // Compute v = t * r + e_2 - m mod q
     let v = polysub(&polyadd(&mul_vec_simple(t, &r, q, &f, omega), &e2, q, f), &m, q, f);
 
@@ -60,7 +58,7 @@ pub fn encrypt(
 /// * `params` - Parameters for the ring-LWE cryptosystem
 /// * `seed` - random seed
 /// # Returns
-/// * `ciphertext_str` - ciphertext string, base64 encoded
+/// * `ciphertext_str` - ciphertext string in base64 encoding
 /// # Example
 /// ```
 /// let params = module_lwe::utils::Parameters::default();

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -1,6 +1,8 @@
 use polynomial_ring::Polynomial;
 use std::collections::HashMap;
 use crate::utils::{Parameters, add_vec, mul_mat_vec_simple, gen_small_vector, gen_uniform_matrix};
+use base64::{engine::general_purpose, Engine as _};
+use bincode;
 
 /// Generate public and secret keys for the ring-LWE cryptosystem
 /// # Arguments
@@ -29,22 +31,22 @@ pub fn keygen(
 }
 
 /// Generate public and secret keys for the ring-LWE cryptosystem and return them as a HashMap
+/// They are serialized and base64 encoded
 /// # Arguments
 /// * `params` - Parameters for the ring-LWE cryptosystem
 /// * `seed` - random seed
 /// # Returns
-/// * `keys` - HashMap containing the public and secret keys
+/// * `keys` - HashMap containing the public and secret keys as base64 encoded strings
 /// # Example
 /// ```
 /// let params = module_lwe::utils::Parameters::default();
 /// let keys = module_lwe::keygen::keygen_string(&params, None);
 /// ```
 pub fn keygen_string(params: &Parameters, seed: Option<u64>) -> HashMap<String, String> {
+    // Generate public and secret keys
+    let (pk, sk) = keygen(params, seed);
 
-    //generate public, secret keys
-    let (pk,sk) = keygen(params,seed);
-
-    // Convert public key to a flattened list of coefficients
+    // Convert the public key to a flattened list of coefficients
     let mut pk_coeffs: Vec<i64> = pk.0
         .iter()
         .flat_map(|row| {
@@ -64,7 +66,7 @@ pub fn keygen_string(params: &Parameters, seed: Option<u64>) -> HashMap<String, 
         })
     );
 
-    // Convert secret key to a flattened list of coefficients
+    // Convert the secret key to a flattened list of coefficients
     let sk_coeffs: Vec<i64> = sk
         .iter()
         .flat_map(|poly| {
@@ -74,20 +76,18 @@ pub fn keygen_string(params: &Parameters, seed: Option<u64>) -> HashMap<String, 
         })
     .collect();
 
-    // Convert the public/secret key coefficients to a comma-separated string
-    let pk_coeffs_str = pk_coeffs.iter()
-        .map(|coef| coef.to_string())
-        .collect::<Vec<String>>()
-        .join(",");
-    let sk_coeffs_str = sk_coeffs.iter()
-        .map(|coef| coef.to_string())
-        .collect::<Vec<String>>()
-        .join(",");
-    
-    //store the secret/public key in a HashMap
+    // Serialize the public and secret key coefficients
+    let pk_bytes = bincode::serialize(&pk_coeffs).expect("Failed to serialize public key coefficients");
+    let sk_bytes = bincode::serialize(&sk_coeffs).expect("Failed to serialize secret key coefficients");
+
+    // Base64 encode the serialized keys
+    let pk_base64 = general_purpose::STANDARD.encode(pk_bytes);
+    let sk_base64 = general_purpose::STANDARD.encode(sk_bytes);
+
+    // Store the Base64 encoded keys in a HashMap
     let mut keys: HashMap<String, String> = HashMap::new();
-    keys.insert(String::from("secret"), sk_coeffs_str);
-    keys.insert(String::from("public"), pk_coeffs_str);
-    
+    keys.insert(String::from("secret"), sk_base64);
+    keys.insert(String::from("public"), pk_base64);
+
     keys
 }

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -57,6 +57,7 @@ pub fn keygen_string(params: &Parameters, seed: Option<u64>) -> HashMap<String, 
             })
         })
         .collect();
+
     pk_coeffs.extend(
         pk.1.iter()
         .flat_map(|poly| {

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -1,8 +1,6 @@
 use polynomial_ring::Polynomial;
 use std::collections::HashMap;
-use crate::utils::{Parameters, add_vec, mul_mat_vec_simple, gen_small_vector, gen_uniform_matrix};
-use base64::{engine::general_purpose, Engine as _};
-use bincode;
+use crate::utils::{Parameters, add_vec, mul_mat_vec_simple, gen_small_vector, gen_uniform_matrix,compress};
 
 /// Generate public and secret keys for the ring-LWE cryptosystem
 /// # Arguments
@@ -77,18 +75,10 @@ pub fn keygen_string(params: &Parameters, seed: Option<u64>) -> HashMap<String, 
         })
     .collect();
 
-    // Serialize the public and secret key coefficients
-    let pk_bytes = bincode::serialize(&pk_coeffs).expect("Failed to serialize public key coefficients");
-    let sk_bytes = bincode::serialize(&sk_coeffs).expect("Failed to serialize secret key coefficients");
-
-    // Base64 encode the serialized keys
-    let pk_base64 = general_purpose::STANDARD.encode(pk_bytes);
-    let sk_base64 = general_purpose::STANDARD.encode(sk_bytes);
-
     // Store the Base64 encoded keys in a HashMap
     let mut keys: HashMap<String, String> = HashMap::new();
-    keys.insert(String::from("secret"), sk_base64);
-    keys.insert(String::from("public"), pk_base64);
+    keys.insert(String::from("secret"), compress(&sk_coeffs));
+    keys.insert(String::from("public"), compress(&pk_coeffs));
 
     keys
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -62,8 +62,6 @@ pub fn add_vec(v0: &Vec<Polynomial<i64>>, v1: &Vec<Polynomial<i64>>, modulus: i6
 /// # Returns
 /// * `result` - polynomial
 pub fn mul_vec_simple(v0: &Vec<Polynomial<i64>>, v1: &Vec<Polynomial<i64>>, modulus: i64, poly_mod: &Polynomial<i64>, omega: i64) -> Polynomial<i64> {
-	println!("v0: {:?}", v0);
-	println!("v1: {:?}", v1);
 	assert!(v0.len() == v1.len());
 	let mut result = Polynomial::new(vec![]);
 	for i in 0..v0.len() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,8 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use ring_lwe::utils::{polyadd, polymul_fast, gen_uniform_poly};
 use ntt::omega;
+use base64::{engine::general_purpose, Engine as _};
+use bincode;
 
 #[derive(Debug)]
 /// default parameters for module-LWE
@@ -143,4 +145,24 @@ pub fn gen_uniform_matrix(size : usize, rank: usize, modulus: i64, seed: Option<
 		}
 	}
 	m
+}
+
+/// seralize and encode a vector of i64 to a base64 encoded string
+/// # Arguments
+/// * `data` - vector of i64
+/// # Returns
+/// * `encoded` - base64 encoded string
+pub fn compress(data: &Vec<i64>) -> String {
+    let serialized_data = bincode::serialize(data).expect("Failed to serialize data");
+    general_purpose::STANDARD.encode(&serialized_data)
+}
+
+/// decode and deserialize a base64 encoded string to a vector of i64
+/// # Arguments
+/// * `base64_str` - base64 encoded string
+/// # Returns
+/// * `decoded_data` - vector of i64
+pub fn decompress(base64_str: &str) -> Vec<i64> {
+    let decoded_bytes = general_purpose::STANDARD.decode(base64_str).expect("Failed to decode base64 string");
+    bincode::deserialize(&decoded_bytes).expect("Failed to deserialize data")
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -62,6 +62,8 @@ pub fn add_vec(v0: &Vec<Polynomial<i64>>, v1: &Vec<Polynomial<i64>>, modulus: i6
 /// # Returns
 /// * `result` - polynomial
 pub fn mul_vec_simple(v0: &Vec<Polynomial<i64>>, v1: &Vec<Polynomial<i64>>, modulus: i64, poly_mod: &Polynomial<i64>, omega: i64) -> Polynomial<i64> {
+	println!("v0: {:?}", v0);
+	println!("v1: {:?}", v1);
 	assert!(v0.len() == v1.len());
 	let mut result = Polynomial::new(vec![]);
 	for i in 0..v0.len() {


### PR DESCRIPTION
use base64 encoding (binary serialization of vectors of integers followed by encoding) for secret key, public key, and ciphertext