### PR TITLE
update version to v0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-lwe"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Implements the module learning-with-errors public key encrpytion scheme."
 license = "MIT"


### PR DESCRIPTION
uses base64 encoding for keys and ciphertext