### PR TITLE
update version to 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module-lwe"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Implements the module learning-with-errors public key encrpytion scheme."
 license = "MIT"


### PR DESCRIPTION
update version with ability to now load/save public/private keys and ciphertext via command line arguments.

uses `clap` for command line argument parsing.