### PR TITLE
remove "message:" from print statement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,7 @@ fn main() {
             };
 
             let message = decrypt_string(&sk_string, &ct_string, &params);
-            println!("message: {:?}", message);
+            println!("{:?}", message);
         }
     }
 }


### PR DESCRIPTION
when printing to the console, just print exactly what the message is